### PR TITLE
Fix the java version question

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -209,7 +209,7 @@ async fn main() {
 
         print!("Java version (11, 17, 18), default: 17): ");
         let mut ver = str_to_int(&read_line());
-        ver = if (8..=20).contains(&ver) { ver } else { 17 };
+        ver = if (11..=20).contains(&ver) { ver } else { 17 };
 
         print!("JRE or JDK (1: JRE, 2: JDK, default: JRE): ");
         let jre = if str_to_int(&read_line()) == 2 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,7 +207,7 @@ async fn main() {
             let _ = fs::remove_dir_all("java");
         }
 
-        print!("Java version (8, 11, 17, 18), default: 17): ");
+        print!("Java version (11, 17, 18), default: 17): ");
         let mut ver = str_to_int(&read_line());
         ver = if (8..=20).contains(&ver) { ver } else { 17 };
 


### PR DESCRIPTION
MCL的readme里面提到`Java 运行时（版本必须 >= 11）`但一键安装中却还可以下载Java8版本